### PR TITLE
refactor: createElement 도입 및 코드 구조 개선

### DIFF
--- a/src/components/home/PostList.js
+++ b/src/components/home/PostList.js
@@ -11,17 +11,21 @@ export class PostList extends HTMLElement {
     this.render();
     window.requestAnimationFrame(() => {
       this.setupTabsListeners();
-      this.updateActiveTab(
-        this.querySelector(`[data-category="${this.activeTab}"]`)
-      );
     });
   }
 
   render() {
+    this.renderTabs();
+    this.renderPosts();
+  }
+
+  renderTabs() {
     this.innerHTML = "";
     const tabsView = document.createElement("tabs-view");
     this.appendChild(tabsView);
+  }
 
+  renderPosts() {
     this.posts.forEach((post) => {
       this.createPostItem(post);
     });
@@ -29,45 +33,47 @@ export class PostList extends HTMLElement {
 
   createPostItem(post) {
     const postItem = document.createElement("post-item");
+    this.setPostAttributes(postItem, post);
+    this.appendChild(postItem);
+  }
+
+  setPostAttributes(postItem, post) {
     postItem.setAttribute("href", `/article/${post.id}`);
     postItem.setAttribute("title", post.title);
     postItem.setAttribute("subtitle", post.subtitle);
     postItem.setAttribute("publishedTime", post.publishedTime);
     postItem.setAttribute("editorName", post.editorName);
     postItem.setAttribute("thumbnailUrl", post.thumbnailUrl);
-    this.appendChild(postItem);
   }
 
   setupTabsListeners() {
-    const tabs = this.querySelector("tabs-view");
-    tabs.addEventListener("click", (event) => {
-      const category = event.target.dataset.category;
-      if (category) {
-        this.filterPostsByCategory(category);
-        this.activeTab = category;
-      }
-    });
+    const tabsView = this.querySelector("tabs-view");
+    tabsView.addEventListener("click", (event) => this.handleTabClick(event));
+  }
+
+  handleTabClick(event) {
+    const category = event.target.dataset.category;
+    const isDifferentCategory = category && category !== this.activeTab;
+    if (isDifferentCategory) {
+      this.activeTab = category;
+      this.filterPostsByCategory(category);
+      const tabsView = this.querySelector("tabs-view");
+      tabsView.updateActiveTab(category);
+    }
   }
 
   filterPostsByCategory(category) {
     this.posts = posts[category];
-    this.updatePostList();
-    window.requestAnimationFrame(() => {
-      this.updateActiveTab(this.querySelector(`[data-category="${category}"]`));
-    });
+    this.updatePosts();
   }
 
-  updatePostList() {
-    const postList = this.querySelectorAll("post-item");
-    postList.forEach((post) => post.remove());
-    this.posts.forEach((post) => {
-      this.createPostItem(post);
-    });
+  updatePosts() {
+    this.clearPosts();
+    this.renderPosts();
   }
 
-  updateActiveTab(selectedTab) {
-    const tabs = this.querySelectorAll(".tabs__item");
-    tabs.forEach((tab) => tab.classList.remove("tabs__item--active"));
-    selectedTab.classList.add("tabs__item--active");
+  clearPosts() {
+    const postItems = this.querySelectorAll("post-item");
+    postItems.forEach((post) => post.remove());
   }
 }

--- a/src/components/home/PostList.js
+++ b/src/components/home/PostList.js
@@ -9,22 +9,23 @@ export class PostList extends HTMLElement {
 
   connectedCallback() {
     this.render();
-    window.requestAnimationFrame(() => {
-      this.setupTabsListeners();
-    });
   }
 
   render() {
-    this.renderTabs();
+    this.replaceContent(this.createTabs());
     this.renderPosts();
   }
 
-  renderTabs() {
-    this.innerHTML = "";
+  createTabs() {
     const tabsView = document.createElement("tabs-view");
-    this.appendChild(tabsView);
+    
+    window.requestAnimationFrame(() => {
+      tabsView.addEventListener("click", (event) => this.handleTabClick(event));
+    });
+    
+    return tabsView;
   }
-
+  
   renderPosts() {
     this.posts.forEach((post) => {
       this.createPostItem(post);
@@ -44,11 +45,6 @@ export class PostList extends HTMLElement {
     postItem.setAttribute("publishedTime", post.publishedTime);
     postItem.setAttribute("editorName", post.editorName);
     postItem.setAttribute("thumbnailUrl", post.thumbnailUrl);
-  }
-
-  setupTabsListeners() {
-    const tabsView = this.querySelector("tabs-view");
-    tabsView.addEventListener("click", (event) => this.handleTabClick(event));
   }
 
   handleTabClick(event) {
@@ -75,5 +71,10 @@ export class PostList extends HTMLElement {
   clearPosts() {
     const postItems = this.querySelectorAll("post-item");
     postItems.forEach((post) => post.remove());
+  }
+
+  replaceContent(newElement) {
+    this.innerHTML = "";
+    this.appendChild(newElement);
   }
 }

--- a/src/components/home/PostList.js
+++ b/src/components/home/PostList.js
@@ -9,33 +9,33 @@ export class PostList extends HTMLElement {
 
   connectedCallback() {
     this.render();
-  }
-
-  render() {
     window.requestAnimationFrame(() => {
-      this.innerHTML = `
-        <tabs-view></tabs-view>
-        ${this.posts
-          .map(
-            (post) => `
-          <post-item
-            href="/article/${post.id}"
-            title="${post.title}"
-            subtitle="${post.subtitle}"
-            publishedTime="${post.publishedTime}"
-            editorName="${post.editorName}"
-            thumbnailUrl="${post.thumbnailUrl}"
-          ></post-item>
-        `
-          )
-          .join("")}
-        `;
-
       this.setupTabsListeners();
       this.updateActiveTab(
         this.querySelector(`[data-category="${this.activeTab}"]`)
       );
     });
+  }
+
+  render() {
+    this.innerHTML = "";
+    const tabsView = document.createElement("tabs-view");
+    this.appendChild(tabsView);
+
+    this.posts.forEach((post) => {
+      this.createPostItem(post);
+    });
+  }
+
+  createPostItem(post) {
+    const postItem = document.createElement("post-item");
+    postItem.setAttribute("href", `/article/${post.id}`);
+    postItem.setAttribute("title", post.title);
+    postItem.setAttribute("subtitle", post.subtitle);
+    postItem.setAttribute("publishedTime", post.publishedTime);
+    postItem.setAttribute("editorName", post.editorName);
+    postItem.setAttribute("thumbnailUrl", post.thumbnailUrl);
+    this.appendChild(postItem);
   }
 
   setupTabsListeners() {
@@ -51,7 +51,18 @@ export class PostList extends HTMLElement {
 
   filterPostsByCategory(category) {
     this.posts = posts[category];
-    this.render();
+    this.updatePostList();
+    window.requestAnimationFrame(() => {
+      this.updateActiveTab(this.querySelector(`[data-category="${category}"]`));
+    });
+  }
+
+  updatePostList() {
+    const postList = this.querySelectorAll("post-item");
+    postList.forEach((post) => post.remove());
+    this.posts.forEach((post) => {
+      this.createPostItem(post);
+    });
   }
 
   updateActiveTab(selectedTab) {

--- a/src/components/home/Tabs.js
+++ b/src/components/home/Tabs.js
@@ -1,15 +1,34 @@
 export class Tabs extends HTMLElement {
-    connectedCallback() {
-      this.render();
-    }
-  
-    render(){
-      this.innerHTML = `
+  connectedCallback() {
+    this.render();
+    this.setupListener();
+  }
+
+  render() {
+    this.innerHTML = `
       <ul class="tabs">
         <li class="tabs__item tabs__item--active" data-category="all">전체</li>
         <li class="tabs__item" data-category="tech">개발</li>
         <li class="tabs__item" data-category="design">디자인</li>
       </ul>
     `;
+  }
+
+  setupListener() {
+    this.addEventListener("click", (event) => {
+      const category = event.target.dataset.category;
+      if (category) {
+        this.updateActiveTab(category);
+      }
+    });
+  }
+
+  updateActiveTab(category) {
+    const selectedTab = this.querySelector(`[data-category="${category}"]`);
+    const tabs = this.querySelectorAll(".tabs__item");
+    tabs.forEach((tab) => tab.classList.remove("tabs__item--active"));
+    if (selectedTab) {
+      selectedTab.classList.add("tabs__item--active");
     }
   }
+}


### PR DESCRIPTION
## 🔎 작업 내용

- `PostList`에서 `createElement`사용하여 DOM 조작 방식을 개선
- `PostItem` 생성 로직을 `createPostItem` 메서드로 분리
- 탭 클릭 관련 로직을 `Tabs.js`로 이동
- https://github.com/f-lab-edu/toss-tech-spa-vanilla/pull/3#discussion_r1739578878 ,https://github.com/f-lab-edu/toss-tech-spa-vanilla/pull/3#discussion_r1739579155 에서 남겨주신 코멘트에 대한 개선 작업도 포함되어있습니다. 

<br/>


## 💬 리뷰 요구사항
- `Tabs.js`로 이동된 탭 클릭 관련 로직이 적절하게 분리되었는지, 그리고 모듈화된 구조가 유지보수에 적합한지 검토 부탁드립니다. 
- 메서드의 역할 분리와 추상화 수준 통일이 잘 이루어졌는지, 추가적으로 개선할 부분이 있는지 확인해주시면 감사하겠습니다. 

